### PR TITLE
Add customizable POML prompt with mini-poml-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ futures-util = "0.3.31"
 toml = "0.9.2"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = { version = "1.0" }
+mini-poml-rs = { git = "https://github.com/linmx0130/mini-poml-rs" }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ $ cd smart-committer && cargo build --release
 $ sudo mv target/release/scommit /usr/local/bin/scommit
 ```
 
+### Customized prompt
+A default prompt that asks the model to generate a summary based on the Git output can be found 
+in [src/config.rs](src/config.rs). If you want to use a customized prompt, draft a 
+[POML](https://microsoft.github.io/poml/latest/) file as `$HOME/.config/smart-committer/user_prompt.poml`.
+
+The git diff output will be parsed as variable `DIFF_CONTENT` and can be referenced in the POML code. 
+Smart-committer uses [`mini-poml-rs`](https://github.com/linmx0130/mini-poml-rs) to parse the POML
+code, which may not support all POML features. See the introduction in `mini-poml-rs` for more details.
+
+### Learn more
 See [our wiki](https://github.com/linmx0130/smart-committer/wiki) for more documents.
 
 ## Copyright

--- a/src/config.rs
+++ b/src/config.rs
@@ -160,7 +160,7 @@ impl UserConfig {
    */
   fn get_user_prompt_file_path() -> Result<std::path::PathBuf, SmartCommitterError> {
     let mut config_file_path = Self::get_config_directory()?;
-    config_file_path.push("user_prompt");
+    config_file_path.push("user_prompt.poml");
 
     Ok(config_file_path)
   }
@@ -235,11 +235,22 @@ impl UserConfig {
   }
 }
 
-const DEFAULT_USER_PROMPT: &str = "Based on this git diff output, draft a commit summary to concisely describe the changes. Requirements:
-1. The first line should be a title within 50 characters. 
-2. Then write a paragraph to describe the changes, what is added, and what is removed. You may use a list of bullet points. 
-3. Do not add any other explanation, do not add any field names.
-```
-{{DIFF_CONTENT}}
-```
-";
+const DEFAULT_USER_PROMPT: &str = r#"<poml>
+<cp caption="Task">
+  <p>Based on this git diff output, draft a commit summary to concisely describe the changes. </p>
+  <h>Requirements</h>
+  <list>
+    <item>The first line should be a title within 50 characters.</item>
+    <item>Then write a paragraph to describe the changes, what is added, and what is removed. You may use a list of bullet points.</item>
+    <item>Do not add any other explanation, do not add any field names.</item>
+  </list>
+</cp>
+
+<h>Git diff output</h>
+<p>```</p>
+<p>
+{{ DIFF_CONTENT }}
+</p>
+<p>```</p>
+</poml>
+"#;


### PR DESCRIPTION
- Introduce mini-poml-rs as a dependency to parse user-defined prompts in POML format, enabling rich markdown-style templates.
- Rename the expected user prompt file from `user_prompt` to `user_prompt.poml`.
- Replace the plain text DEFAULT_USER_PROMPT with an embedded POML template that preserves existing wording while showing how to use POML markup (`<poml>`, `<cp>`, `<list>`, etc.) and the variable placeholder `{{ DIFF_CONTENT }}`.
- Update README with usage instructions for creating a customized `user_prompt.poml` file under `$HOME/.config/smart-committer/` and documenting POML feature support.
- Change variable expansion from simple string-replace to JSON-backed rendering with the POML parser, and raise the max_tokens limit to 8192 to accommodate larger rendered prompts.